### PR TITLE
fix: dxlander folder renaming breaks app - use relative paths

### DIFF
--- a/apps/api/src/routes/configs.ts
+++ b/apps/api/src/routes/configs.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { router, protectedProcedure, IdSchema } from '@dxlander/shared';
+import { router, protectedProcedure, IdSchema, resolveProjectPath } from '@dxlander/shared';
 import { ConfigGenerationService } from '../services/config-generation.service';
 
 const GenerateConfigSchema = z.object({
@@ -303,7 +303,12 @@ export const configsRouter = router({
           throw new Error('Configuration local path not found');
         }
 
-        const summaryPath = path.join(configSet.localPath, '_summary.json');
+        const resolvedPath = resolveProjectPath(configSet.localPath);
+        if (!resolvedPath) {
+          throw new Error('Could not resolve configuration path');
+        }
+
+        const summaryPath = path.join(resolvedPath, '_summary.json');
         await fs.writeFile(summaryPath, JSON.stringify(input.metadata, null, 2), 'utf-8');
 
         await db

--- a/apps/api/src/services/config-generation.service.ts
+++ b/apps/api/src/services/config-generation.service.ts
@@ -15,6 +15,8 @@ import {
   getConfigDir,
   getProjectConfigsDir,
   isPathSafe,
+  getRelativeProjectPath,
+  resolveProjectPath,
 } from '@dxlander/shared';
 import { randomUUID } from 'crypto';
 import { and, desc, eq } from 'drizzle-orm';
@@ -87,7 +89,7 @@ export class ConfigGenerationService {
         userId,
         name: configName,
         version: newVersion,
-        localPath: configPath,
+        localPath: getRelativeProjectPath(configPath), // Store RELATIVE path
         generatedBy: aiProvider.provider,
         status: 'generating',
         startedAt: new Date(),
@@ -129,6 +131,12 @@ export class ConfigGenerationService {
         throw new Error('Config set or localPath not found');
       }
 
+      // Resolve relative path to absolute for file operations
+      const resolvedConfigPath = resolveProjectPath(configSet.localPath);
+      if (!resolvedConfigPath) {
+        throw new Error('Could not resolve config path');
+      }
+
       await this.logConfigActivity(
         configSetId,
         'start_generation',
@@ -141,7 +149,7 @@ export class ConfigGenerationService {
         analysisResult: analysisResults,
         projectContext: {
           files: [],
-          projectPath: configSet.localPath,
+          projectPath: resolvedConfigPath, // Use RESOLVED absolute path
           readme: analysisResults.projectStructure.documentationFiles[0],
           onProgress: async (event) => {
             await this.logConfigActivity(
@@ -212,7 +220,7 @@ export class ConfigGenerationService {
           const fileExtension = fileName.split('.').pop() || 'txt';
           const fileType = fileExtension || 'text';
 
-          if (!isPathSafe(configSet.localPath, fileName)) {
+          if (!isPathSafe(resolvedConfigPath, fileName)) {
             await this.logConfigActivity(
               configSetId,
               'read_file',
@@ -223,7 +231,7 @@ export class ConfigGenerationService {
             continue;
           }
 
-          const filePath = path.join(configSet.localPath, fileName);
+          const filePath = path.join(resolvedConfigPath, fileName);
           let content = '';
 
           try {

--- a/apps/api/src/services/config-generation.service.ts
+++ b/apps/api/src/services/config-generation.service.ts
@@ -260,7 +260,7 @@ export class ConfigGenerationService {
         }
       }
 
-      const summaryPath = path.join(configSet.localPath, '_summary.json');
+      const summaryPath = path.join(resolvedConfigPath, '_summary.json');
       try {
         await fs.access(summaryPath);
       } catch {
@@ -353,9 +353,13 @@ export class ConfigGenerationService {
       try {
         const fs = await import('fs/promises');
         const path = await import('path');
-        const summaryPath = path.join(configSet.localPath, '_summary.json');
-        const summaryContent = await fs.readFile(summaryPath, 'utf-8');
-        metadata = JSON.parse(summaryContent);
+        const { resolveProjectPath } = await import('@dxlander/shared');
+        const resolvedPath = resolveProjectPath(configSet.localPath);
+        if (resolvedPath) {
+          const summaryPath = path.join(resolvedPath, '_summary.json');
+          const summaryContent = await fs.readFile(summaryPath, 'utf-8');
+          metadata = JSON.parse(summaryContent);
+        }
       } catch {
         // File doesn't exist or couldn't be read
       }

--- a/apps/api/src/services/config-service.service.ts
+++ b/apps/api/src/services/config-service.service.ts
@@ -11,6 +11,7 @@ import {
   PROVISIONABLE_SERVICES,
   generateSecurePassword,
   buildConnectionString,
+  resolveProjectPath,
 } from '@dxlander/shared';
 import { SecretService } from './secret.service';
 
@@ -514,7 +515,11 @@ export class ConfigServiceService {
       try {
         const fs = await import('fs/promises');
         const path = await import('path');
-        const summaryPath = path.join(config.localPath, '_summary.json');
+        const resolvedPath = resolveProjectPath(config.localPath);
+        if (!resolvedPath) {
+          throw new Error('Could not resolve config path');
+        }
+        const summaryPath = path.join(resolvedPath, '_summary.json');
         const summaryContent = await fs.readFile(summaryPath, 'utf-8');
         const metadata = JSON.parse(summaryContent);
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -121,6 +121,30 @@ export default [
         },
     },
 
+    // Path Resolution Enforcement for API
+    // Prevents direct usage of .localPath in path.join() without resolveProjectPath()
+    // localPath stores RELATIVE paths - must be resolved to absolute before file operations
+    {
+        files: ['apps/api/**/*.{ts,tsx}'],
+        rules: {
+            'no-restricted-syntax': [
+                'error',
+                {
+                    selector: 'CallExpression[callee.property.name="join"][arguments.0.property.name="localPath"]',
+                    message: '❌ Do not use .localPath directly in path.join(). localPath stores RELATIVE paths. Use resolveProjectPath(entity.localPath) first to get absolute path.',
+                },
+                {
+                    selector: 'CallExpression[callee.property.name="existsSync"][arguments.0.property.name="localPath"]',
+                    message: '❌ Do not use .localPath directly in fs.existsSync(). localPath stores RELATIVE paths. Use resolveProjectPath(entity.localPath) first',
+                },
+                {
+                    selector: 'CallExpression[callee.property.name="readFileSync"][arguments.0.property.name="localPath"]',
+                    message: '❌ Do not use .localPath directly in fs.readFileSync(). localPath stores RELATIVE paths. Use resolveProjectPath(entity.localPath) first',
+                },
+            ],
+        },
+    },
+
     // React/Next.js specific configuration for web app
     {
         files: ['apps/web/**/*.{ts,tsx}'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -124,22 +124,29 @@ export default [
     // Path Resolution Enforcement for API
     // Prevents direct usage of .localPath in path.join() without resolveProjectPath()
     // localPath stores RELATIVE paths - must be resolved to absolute before file operations
+    // NOTE: This block overrides no-restricted-syntax from apps/**, so we must include domain-type guardrail here too
     {
         files: ['apps/api/**/*.{ts,tsx}'],
         rules: {
             'no-restricted-syntax': [
                 'error',
+                // Domain type guardrail (inherited from apps/** - must be duplicated here since this overrides)
+                {
+                    selector: 'TSInterfaceDeclaration[id.name=/^(Project|Deployment|User|Integration|DeploymentCredential|ConfigSet|ProviderTestResult|ProviderTestConfig|ProjectFile)$/]',
+                    message: '❌ Do not redefine domain types as interfaces. Import from @dxlander/shared instead.',
+                },
+                // Path resolution guardrails (API-specific)
                 {
                     selector: 'CallExpression[callee.property.name="join"][arguments.0.property.name="localPath"]',
                     message: '❌ Do not use .localPath directly in path.join(). localPath stores RELATIVE paths. Use resolveProjectPath(entity.localPath) first to get absolute path.',
                 },
                 {
                     selector: 'CallExpression[callee.property.name="existsSync"][arguments.0.property.name="localPath"]',
-                    message: '❌ Do not use .localPath directly in fs.existsSync(). localPath stores RELATIVE paths. Use resolveProjectPath(entity.localPath) first',
+                    message: '❌ Do not use .localPath directly in fs.existsSync(). localPath stores RELATIVE paths. Use resolveProjectPath(entity.localPath) first.',
                 },
                 {
                     selector: 'CallExpression[callee.property.name="readFileSync"][arguments.0.property.name="localPath"]',
-                    message: '❌ Do not use .localPath directly in fs.readFileSync(). localPath stores RELATIVE paths. Use resolveProjectPath(entity.localPath) first',
+                    message: '❌ Do not use .localPath directly in fs.readFileSync(). localPath stores RELATIVE paths. Use resolveProjectPath(entity.localPath) first.',
                 },
             ],
         },

--- a/packages/shared/src/services/file-storage.ts
+++ b/packages/shared/src/services/file-storage.ts
@@ -60,10 +60,23 @@ export function getRelativeProjectPath(absolutePath: string): string {
   const resolvedPath = path.resolve(absolutePath);
   const resolvedHome = path.resolve(dxlanderHome);
 
-  if (resolvedPath.startsWith(resolvedHome)) {
+  // On Windows, drive letters can differ in case (C: vs c:) but represent the same path
+  // Use case-insensitive comparison on Windows
+  const isWindows = process.platform === 'win32';
+  const normalizedPath = isWindows ? resolvedPath.toLowerCase() : resolvedPath;
+  const normalizedHome = isWindows ? resolvedHome.toLowerCase() : resolvedHome;
+  const homeWithSep = normalizedHome + path.sep;
+
+  if (normalizedPath === normalizedHome || normalizedPath.startsWith(homeWithSep)) {
     return path.relative(resolvedHome, resolvedPath);
   }
-  // If not in DXLANDER_HOME, return as-is
+
+  // Path is outside DXLANDER_HOME - this shouldn't happen in normal usage
+  // Log warning and return as-is for backward compatibility
+  console.warn(
+    `[Path Warning] Path "${absolutePath}" is outside DXLANDER_HOME. ` +
+      `This may cause portability issues. Ensure all project paths are within ${dxlanderHome}`
+  );
   return absolutePath;
 }
 

--- a/packages/shared/src/services/zip-upload.ts
+++ b/packages/shared/src/services/zip-upload.ts
@@ -7,6 +7,7 @@ import {
   ensureDir,
   getDirSize,
   countFiles,
+  getRelativeProjectPath,
 } from './file-storage';
 
 /**
@@ -80,7 +81,7 @@ export async function extractZipFile(
     files,
     filesCount,
     totalSize,
-    localPath: projectRoot, // Return project root, not files dir
+    localPath: getRelativeProjectPath(projectRoot), // Return RELATIVE path for portability
   };
 }
 

--- a/tests/unit/packages/shared/persist-temp-project-directory.test.ts
+++ b/tests/unit/packages/shared/persist-temp-project-directory.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import {
   persistTempProjectDirectory,
   getProjectDir,
+  getRelativeProjectPath,
 } from '../../../../packages/shared/src/services/file-storage';
 
 const PROJECT_ID = 'test-project';
@@ -41,7 +42,8 @@ describe('persistTempProjectDirectory', () => {
     const result = persistTempProjectDirectory(PROJECT_ID, extractPath);
 
     const projectRoot = getProjectDir(PROJECT_ID);
-    expect(result.localPath).toBe(projectRoot);
+    // localPath is now returned as RELATIVE path for portability
+    expect(result.localPath).toBe(getRelativeProjectPath(projectRoot));
     expect(result.filesCount).toBe(files.length);
 
     const expectedSize = files.reduce((total, file) => total + Buffer.byteLength(file.contents), 0);


### PR DESCRIPTION
## Problem

so basically when you rename or move the .dxlander folder the whole app just breaks. this happens because we were storing absolute paths in the database like C:\Users\whatever\.dxlander\projects\abc123 and when the folder moves those paths dont work anymore.

## What I Changed

- added two new functions getRelativeProjectPath() and resolveProjectPath() to handle path conversions
- now we store relative paths in database instead like just "projects/abc123" 
- updated file-storage.ts, zip-upload.ts, config-generation service, and configs route to use these new functions
- created a migration script so existing users can convert their old absolute paths to relative ones

## Files Changed

- packages/shared/src/services/file-storage.ts - added the path utility functions
- packages/shared/src/services/zip-upload.ts - uses relative paths now
- apps/api/src/services/config-generation.service.ts - stores relative, resolves when doing file operations
- apps/api/src/routes/configs.ts - resolves paths before file operations
- scripts/migrate-to-relative-paths.mjs - new migration script for existing data

## How to Use

for existing installations run the migration script first:
node scripts/migrate-to-relative-paths.mjs

then you can rename the folder and just set DXLANDER_HOME to the new location and restart

## Type of Change

- [x] Bug fix (fixes the folder renaming issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Projects and uploaded archives now store portable relative project paths; server flows resolve these to absolute locations for reliable file reads, validations, and artifact handling.
* **Bug Fixes**
  * Stronger errors and path-safety checks when a project/config path cannot be resolved to prevent silent file-access failures.
* **Tests**
  * Updated tests to expect relative-path behavior for persisted project directories.
* **Style**
  * Added lint rules preventing unsafe direct filesystem use of raw local paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->